### PR TITLE
Backport two fix patches from upstream collectd repository

### DIFF
--- a/src/python.c
+++ b/src/python.c
@@ -1141,7 +1141,13 @@ static void *cpy_interactive(void *pipefd) {
 #else
   PyOS_AfterFork_Child();
 #endif
+#if PY_VERSION_HEX < 0x03090000
+  // deprecated. Called by Py_Initialize(). Removed in Py3.11
+  // https://docs.python.org/3/c-api/init.html#c.PyEval_InitThreads
   PyEval_InitThreads();
+#else
+  Py_Initialize();
+#endif
   close(*(int *)pipefd);
   PyRun_InteractiveLoop(stdin, "<stdin>");
   PyOS_setsig(SIGINT, cur_sig);
@@ -1178,7 +1184,13 @@ static int cpy_init(void) {
       ;
     (void)close(pipefd[0]);
   } else {
+#if PY_VERSION_HEX < 0x03090000
+    // deprecated. Called by Py_Initialize(). Removed in Py3.11
+    // https://docs.python.org/3/c-api/init.html#c.PyEval_InitThreads
     PyEval_InitThreads();
+#else
+    Py_Initialize();
+#endif
     state = PyEval_SaveThread();
   }
   CPY_LOCK_THREADS

--- a/src/snmp.c
+++ b/src/snmp.c
@@ -704,12 +704,8 @@ static int csnmp_config_add_host_priv_protocol(host_definition_t *hd,
   if (strcasecmp("AES", buffer) == 0) {
     hd->priv_protocol = usmAESPrivProtocol;
     hd->priv_protocol_len = sizeof(usmAESPrivProtocol) / sizeof(oid);
-  } else if (strcasecmp("DES", buffer) == 0) {
-    hd->priv_protocol = usmDESPrivProtocol;
-    hd->priv_protocol_len = sizeof(usmDESPrivProtocol) / sizeof(oid);
   } else {
-    WARNING("snmp plugin: The `PrivProtocol' config option must be `AES' or "
-            "`DES'.");
+    WARNING("snmp plugin: The `PrivProtocol' config option must be `AES'.");
     return -1;
   }
 


### PR DESCRIPTION
These two patches can fix the following build errors:

> src/python.c: In function 'cpy_interactive':
> src/python.c:1144:3: error: 'PyEval_InitThreads' is deprecated [-Werror=deprecated-declarations]
>  1144 |   PyEval_InitThreads();
>       |   ^~~~~~~~~~~~~~~~~~
> In file included from /usr/include/python3.9/Python.h:140,
>                  from src/python.c:27:
> /usr/include/python3.9/ceval.h:130:37: note: declared here
>   130 | Py_DEPRECATED(3.9) PyAPI_FUNC(void) PyEval_InitThreads(void);
>       |                                     ^~~~~~~~~~~~~~~~~~
> src/python.c: In function 'cpy_init':
> src/python.c:1181:5: error: 'PyEval_InitThreads' is deprecated [-Werror=deprecated-declarations]
>  1181 |     PyEval_InitThreads();
>       |     ^~~~~~~~~~~~~~~~~~
> In file included from /usr/include/python3.9/Python.h:140,
>                  from src/python.c:27:
> /usr/include/python3.9/ceval.h:130:37: note: declared here
>   130 | Py_DEPRECATED(3.9) PyAPI_FUNC(void) PyEval_InitThreads(void);
>       |                                     ^~~~~~~~~~~~~~~~~~
> cc1: all warnings being treated as errors
> make[2]: *** [Makefile:8888: src/python_la-python.lo] Error 1

> src/snmp.c: In function ‘csnmp_config_add_host_priv_protocol’:
> src/snmp.c:708:25: error: ‘usmDESPrivProtocol’ undeclared (first use in this function); did you mean ‘usmAESPrivProtocol’?
>   708 |     hd->priv_protocol = usmDESPrivProtocol;
>       |                         ^~~~~~~~~~~~~~~~~~
>       |                         usmAESPrivProtocol
> src/snmp.c:708:25: note: each undeclared identifier is reported only once for each function it appears in
> make[1]: *** [Makefile:8982: src/snmp_la-snmp.lo] Error 1
> make[1]: Leaving directory '/root/ScaleWX-collectd'
> make: *** [Makefile:5670: all] Error 2