### PR TITLE
Backport five fix patches from upstream collectd repository

### DIFF
--- a/src/cpython.h
+++ b/src/cpython.h
@@ -24,9 +24,15 @@
  *   Sven Trenkel <collectd at semidefinite.de>
  **/
 
+#include <Python.h>
 /* Some python versions don't include this by default. */
-
+#if PY_VERSION_HEX < 0x030B0000
+/*
+ * Python 3.11 move longintrepr.h to cpython/longintrepr.h
+ * And it's always included
+ */
 #include <longintrepr.h>
+#endif /* PY_VERSION_HEX < 0x030B0000 */
 
 /* These two macros are basically Py_BEGIN_ALLOW_THREADS and
  * Py_BEGIN_ALLOW_THREADS

--- a/src/libcollectdclient/client.c
+++ b/src/libcollectdclient/client.c
@@ -309,7 +309,7 @@ static int lcc_receive(lcc_connection_t *c, /* {{{ */
     ptr++;
 
   /* Now copy the message. */
-  strncpy(res.message, ptr, sizeof(res.message));
+  strncpy(res.message, ptr, sizeof(res.message) - 1);
   res.message[sizeof(res.message) - 1] = '\0';
 
   /* Error or no lines follow: We're done. */

--- a/src/write_prometheus.c
+++ b/src/write_prometheus.c
@@ -246,8 +246,8 @@ static MHD_RESULT http_handler(void *cls, struct MHD_Connection *connection,
    * Apparently not everything has been initialized yet or so; the docs are not
    * very specific on the issue. */
   if (*connection_state == NULL) {
-    /* set to a random non-NULL pointer. */
-    *connection_state = &(int){42};
+    /* keep track of connection state */
+    *connection_state = &"called";
     return MHD_YES;
   }
 


### PR DESCRIPTION
**These five patches can fix the following build errors on Rockylinux 10.1:**
Error1:
```
src/write_prometheus.c: In function 'http_handler':
src/write_prometheus.c:250:23: error: storing the address of local variable '<anonymous>' in '*connection_state_22(D)' [-Werror=dangling-pointer=]
  250 |     *connection_state = &(int){42};
      |     ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
src/write_prometheus.c:250:31: note: '<anonymous>' declared here
  250 |     *connection_state = &(int){42};
      |  
```
Error2:
```
src/libcollectdclient/client.c: In function 'lcc_sendreceive':
src/libcollectdclient/client.c:312:3: error: 'strncpy' specified bound 1024 equals destination size [-Werror=stringop-truncation]
  312 |   strncpy(res.message, ptr, sizeof(res.message));
      |   ^
```
Error3:
```
src/python.c: In function 'cpy_init_python':
src/python.c:1320:3: error: 'PySys_SetArgv' is deprecated [-Werror=deprecated-declarations]
 1320 |   PySys_SetArgv(1, &argv);
      |   ^~~~~~~~~~~~~
In file included from /usr/include/python3.12/Python.h:96,
                 from src/python.c:27:
/usr/include/python3.12/sysmodule.h:13:38: note: declared here
   13 | Py_DEPRECATED(3.11) PyAPI_FUNC(void) PySys_SetArgv(int, wchar_t **);
      | 
```
Error4:
```
In file included from src/pyconfig.c:34:
src/cpython.h:29:10: fatal error: longintrepr.h: No such file or directory
   29 | #include <longintrepr.h>
      | 
```
Error5:
```
src/utils/curl_stats/curl_stats.c:128:5: error: 'CURLINFO_SIZE_UPLOAD' is deprecated: since 7.55.0. Use CURLINFO_SIZE_UPLOAD_T [-Werror=deprecated-declarations]
  128 |     SPEC(size_upload, "SizeUpload", dispatch_gauge, "bytes",
      |     ^~~~
```